### PR TITLE
Display a particular theme options section via query string

### DIFF
--- a/classes/struts/section.php
+++ b/classes/struts/section.php
@@ -72,7 +72,7 @@ class Struts_Section {
 	}
 
 	public function to_html() {
-		echo "<div class='struts-section'>";
+		echo "<div id='{$this->id()}' class='struts-section'>";
 		echo "<h3>{$this->title()} <a href='#'>" . __( 'Edit', 'struts' ) . '</a></h3>';
 		echo "<div class='struts-section-body clear'>";
 		foreach ( $this->options() as $option ) {

--- a/javascripts/struts.js
+++ b/javascripts/struts.js
@@ -44,4 +44,33 @@ jQuery(document).ready(function($) {
     }
     return false;
   });
+  
+  
+  /**
+   * Option Section Display
+   * 
+   * Display an options section if the section param 
+   * is passed via a query string in the url.
+   * 
+   * Example: <php get_admin_url() . 'themes.php?page=yourtheme_options&section=logo_section'
+   */
+	var section_id = getParameterByName('section');
+	
+	if( section_id ) {
+		var section_id = '#' + section_id;
+		jQuery('h3', section_id).addClass('open');
+		jQuery('.struts-section-body', section_id).css('display','block');
+	}
+	
+	function getParameterByName(name) {
+	  name = name.replace(/[\[]/, "\\\[").replace(/[\]]/, "\\\]");
+	  var regexS = "[\\?&]" + name + "=([^&#]*)";
+	  var regex = new RegExp(regexS);
+	  var results = regex.exec(window.location.search);
+	  if(results == null)
+	    return "";
+	  else
+	    return decodeURIComponent(results[1].replace(/\+/g, " "));
+	}
+
 });


### PR DESCRIPTION
First off, great work with this theme options framework. I've been working with it more and more lately and thought I would share something I find useful.

Often times I reference certain options in the theme itself, documentation, or where ever. Instead of sending the user to the Theme Options page, I've found it helpful to display the section in which the option or section I'm referencing resides. To do this, you can simply give the url string a section parameter with the section name:

``` php
<?php esc_url( get_admin_url() . 'themes.php?page=themename_options&section=section_name' ) ?>
```

In this case, you would need to update the "themename_options" and "section_name" values to coincide with your theme.

I thought I would share. Again, great work :)

Luke
